### PR TITLE
Update to winit 0.20.0, fix DPI api change errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ std_web = { version = "0.4.20", package = "stdweb", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 webgl_stdweb = { version = "0.3.0", optional = true }
 web_sys = { version = "0.3.22", package = "web-sys", optional = true, features = ["HtmlHeadElement"] }
-winit = "0.20.0-alpha6"
+winit = "0.20.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.22.0-alpha3", optional = true }

--- a/src/event.rs
+++ b/src/event.rs
@@ -25,11 +25,7 @@ pub enum Event {
     ///
     /// Operating systems often have key repeat settings that cause duplicate events to be
     /// generated for a single press.
-    KeyboardInput {
-        key: Key,
-        modifiers: Modifiers,
-        state: ElementState,
-    },
+    KeyboardInput { key: Key, state: ElementState },
     /// A given pointer has entered the window
     MouseEntered { pointer: Pointer },
     /// A given pointer has left the window
@@ -38,21 +34,22 @@ pub enum Event {
     MouseMoved {
         pointer: Pointer,
         position: Vector2<f32>,
-        modifiers: Modifiers,
     },
     /// The mousewheel has scrolled, either in lines or pixels (depending on the input method)
     MouseWheel {
         pointer: Pointer,
         delta: MouseScrollDelta,
-        modifiers: Modifiers,
     },
     /// A mouse button has been pressed or released
     MouseInput {
         pointer: Pointer,
         state: ElementState,
         button: MouseButton,
-        modifiers: Modifiers,
     },
+
+    /// The keyboard modifiers have changed.
+    ModifiersChanged { modifiers: Modifiers },
+
     /// A gamepad button has been pressed or released, or an axis has changed
     GamepadEvent { id: GamepadId, event: GamepadEvent },
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -127,8 +127,8 @@ fn process_gilrs_events(
 fn convert_winit(event: winit::event::WindowEvent) -> Option<Event> {
     use winit::event::WindowEvent::*;
     Some(match event {
-        Resized(ls) => Event::Resized(ls_to_vec(ls)),
-        HiDpiFactorChanged(scale) => Event::ScaleFactorChanged(scale as f32),
+        Resized(ls) => Event::Resized(ps_to_vec(ls)),
+        ScaleFactorChanged{scale_factor, new_inner_size} => Event::ScaleFactorChanged(scale_factor as f32),
         ReceivedCharacter(c) => Event::ReceivedCharacter(c),
         Focused(f) => Event::Focused(f),
         KeyboardInput {
@@ -151,7 +151,7 @@ fn convert_winit(event: winit::event::WindowEvent) -> Option<Event> {
             modifiers,
         } => Event::MouseMoved {
             pointer: Pointer(device_id),
-            position: lp_to_vec(position),
+            position: pp_to_vec(position),
             modifiers: modifiers.into(),
         },
         CursorEntered { device_id } => Event::MouseEntered {
@@ -253,16 +253,16 @@ fn convert_gilrs_axis(axis: gilrs::ev::Axis) -> Option<GamepadAxis> {
     })
 }
 
-fn ls_to_vec(ls: winit::dpi::LogicalSize) -> Vector2<f32> {
+fn ps_to_vec<P: winit::dpi::Pixel>(ls: winit::dpi::PhysicalSize<P>) -> Vector2<f32> {
     Vector2 {
-        x: ls.width as f32,
-        y: ls.height as f32,
+        x: ls.width.cast(),
+        y: ls.height.cast(),
     }
 }
 
-fn lp_to_vec(ls: winit::dpi::LogicalPosition) -> Vector2<f32> {
+fn pp_to_vec<P: winit::dpi::Pixel>(ls: winit::dpi::PhysicalPosition<P>) -> Vector2<f32> {
     Vector2 {
-        x: ls.x as f32,
-        y: ls.y as f32,
+        x: ls.x.cast(),
+        y: ls.y.cast(),
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,7 +4,7 @@ use glow::Context;
 use glutin::{PossiblyCurrent, WindowedContext};
 use mint::Vector2;
 use std::sync::Arc;
-use winit::dpi::LogicalSize;
+use winit::dpi::PhysicalSize;
 use winit::event_loop::EventLoop;
 use winit::monitor::MonitorHandle;
 use winit::window::{Fullscreen, Window as WinitWindow, WindowBuilder};
@@ -160,7 +160,7 @@ fn settings_to_wb(el: &EventLoop<()>, settings: &Settings) -> WindowBuilder {
     #[cfg(not(feature = "image"))]
     let icon = None;
     WindowBuilder::new()
-        .with_inner_size(LogicalSize {
+        .with_inner_size(PhysicalSize {
             width: settings.size.x as f64,
             height: settings.size.y as f64,
         })
@@ -260,7 +260,7 @@ impl WindowContents {
     }
 
     pub fn set_size(&self, size: Vector2<f32>) {
-        self.window().set_inner_size(LogicalSize {
+        self.window().set_inner_size(PhysicalSize {
             width: size.x as f64,
             height: size.y as f64,
         });
@@ -277,10 +277,9 @@ impl WindowContents {
         ));
     }
 
-    pub(crate) fn resize(&self, _size: &LogicalSize) {
+    pub(crate) fn resize<P: winit::dpi::Pixel>(&self, _size: &PhysicalSize<P>) {
         #[cfg(all(feature = "gl", not(target_arch = "wasm32")))]
-        self.window
-            .resize(_size.to_physical(self.window.window().hidpi_factor()));
+        self.window.resize(_size);
     }
 
     #[cfg(feature = "gl")]
@@ -290,7 +289,7 @@ impl WindowContents {
     }
 
     pub fn scale(&self) -> f32 {
-        self.window().hidpi_factor() as f32
+        self.window().scale_factor() as f32
     }
 
     #[inline]


### PR DESCRIPTION
This is mostly a dumb fix for the errors so blinds builds, I've yet to wrap my head around the DPI stuff so I hope someone more experienced can come along and make sure this change doesn't cause any regressions.

Edit;
Due to CI I had to also resolve the deprecation warnings for Modifiers portion of the event handler, this is probably not the best way to do it though, worth considering moving all device events next to the new modifiers handler?