### PR TITLE
RFC: Non-Blocking Task Concurrency

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt update && sudo apt install libudev-dev
     - name: Check formatting
+      if: matrix.rust == 'stable'
       run: cargo fmt -- --check
     - name: Clippy desktop
       run: cargo clippy -- -D warnings

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,3 +38,5 @@ jobs:
       run: cargo clippy --target wasm32-unknown-unknown --features web-sys,gl -- -D warnings
     - name: Examples
       run: cargo check --examples
+    - name: Examples with GL enabled
+      run: cargo check --examples --features gl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ winit = "0.20.0"
 
 [dev-dependencies]
 platter = "*"
+async-std = "*"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.22", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,8 @@ webgl_stdweb = { version = "0.3.0", optional = true }
 web_sys = { version = "0.3.22", package = "web-sys", optional = true, features = ["HtmlHeadElement"] }
 winit = "0.20.0"
 
+[dev-dependencies]
+platter = "*"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.22", optional = true }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -11,7 +11,7 @@ async fn app(_window: Window, mut events: EventStream<Event>) {
                 key: Key::Escape, ..
             } = ev
             {
-                break 'outer; // this now stop working because the main loop
+                break 'outer;
             }
             println!("{:?}", ev);
         }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -5,13 +5,13 @@ fn main() {
 }
 
 async fn app(_window: Window, mut events: EventStream<Event>) {
-    loop {
+    'outer: loop {
         while let Some(ev) = events.next_event().await {
             if let Event::KeyboardInput {
                 key: Key::Escape, ..
             } = ev
             {
-                break;
+                break 'outer; // this now stop working because the main loop
             }
             println!("{:?}", ev);
         }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -4,7 +4,7 @@ fn main() {
     run(Settings::default(), app);
 }
 
-async fn app(_window: Window, mut events: EventStream) {
+async fn app(_window: Window, mut events: EventStream<Event>) {
     loop {
         while let Some(ev) = events.next_event().await {
             if let Event::KeyboardInput {

--- a/examples/echo_gl.rs
+++ b/examples/echo_gl.rs
@@ -12,9 +12,10 @@ async fn app(_window: Window, _ctx: Context, mut events: EventStream<Event>) {
                 key: Key::Escape, ..
             } = ev
             {
-                break 'outer; // this now stop working because the main loop
+                break 'outer;
             }
             println!("{:?}", ev);
         }
+        // TODO: use the glow context for something basic
     }
 }

--- a/examples/echo_gl.rs
+++ b/examples/echo_gl.rs
@@ -1,0 +1,20 @@
+use blinds::{run_gl, Event, EventStream, Key, Settings, Window};
+use glow::Context;
+
+fn main() {
+    run_gl(Settings::default(), app);
+}
+
+async fn app(_window: Window, _ctx: Context, mut events: EventStream<Event>) {
+    'outer: loop {
+        while let Some(ev) = events.next_event().await {
+            if let Event::KeyboardInput {
+                key: Key::Escape, ..
+            } = ev
+            {
+                break 'outer; // this now stop working because the main loop
+            }
+            println!("{:?}", ev);
+        }
+    }
+}

--- a/examples/echo_gl.rs
+++ b/examples/echo_gl.rs
@@ -1,10 +1,14 @@
+#[cfg(feature = "gl")]
 use blinds::{run_gl, Event, EventStream, Key, Settings, Window};
+#[cfg(feature = "gl")]
 use glow::Context;
 
 fn main() {
+    #[cfg(feature = "gl")]
     run_gl(Settings::default(), app);
 }
 
+#[cfg(feature = "gl")]
 async fn app(_window: Window, _ctx: Context, mut events: EventStream<Event>) {
     'outer: loop {
         while let Some(ev) = events.next_event().await {

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -1,7 +1,7 @@
 extern crate platter;
 extern crate async_std;
 
-use blinds::{run_custom, Event as BlindsEvent, EventContext, Settings, Window};
+use blinds::{run_custom, Event as BlindsEvent, EventContext, Settings, Window, Key};
 use platter::load_file;
 use async_std::task::sleep;
 use std::time::Duration;
@@ -30,7 +30,7 @@ async fn tick_loop(context: EventContext<MyEvent>) {
     }
 }
 
-async fn app(_window: Window, mut context: EventContext<MyEvent>) {
+async fn app(window: Window, mut context: EventContext<MyEvent>) {
     
     // Start a long-running "background" task
     context.spawn(tick_loop);
@@ -41,10 +41,19 @@ async fn app(_window: Window, mut context: EventContext<MyEvent>) {
         inner_context.dispatch(MyEvent::AssetReady)
     });
 
-    loop {
+    'outer: loop {
         
         while let Some(ev) = context.stream.next_event().await {
-            println!("Got event: {:?}", ev)
+            println!("Got event: {:?}", ev);
+
+            if let MyEvent::Blinds(BlindsEvent::KeyboardInput {
+                key: Key::Escape, ..
+            }) = ev
+            {
+                // window.
+                break 'outer;
+            }
+
             // TODO: Kick off a new task every time you press a certain key (maybe only one pending at once)
         }
 

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -26,7 +26,6 @@ fn main() {
 }
 
 async fn tick_loop(context: EventContext<MyEvent>) {
-    // some sort of sleep would be nice
     loop {
         println!("Ticking");
         (&context).dispatch(MyEvent::Ticked);
@@ -68,7 +67,7 @@ async fn app(_window: Window, mut context: EventContext<MyEvent>) {
                 key: Key::Space, ..
             }) = ev
             {
-                // Start a first-party
+                // Start a first-party handler, which eventually notifies a first-party event on completion
                 context.spawn(button_handler);
             }
         }

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -1,23 +1,21 @@
 extern crate platter;
 
-use blinds::{run, Event, EventStream, Key, Settings, Window};
+use blinds::{run_custom, Event as BlindsEvent, EventContext, Settings, Window};
 
-use platter::load_file;
-use std::future::Future;
-use std::string::String;
+#[derive(Debug)]
+enum MyEvent {
+    Blinds(BlindsEvent)
+}
+
+impl From<BlindsEvent> for MyEvent{
+    fn from(e: BlindsEvent) -> Self { MyEvent::Blinds(e) }
+}
 
 fn main() {
-    run(Settings::default(), app);
+    run_custom(Settings::default(), app);
 }
 
-#[cfg(target_arch = "wasm32")]
-async fn echo_request() -> Result<String> {
-    let url = "https://postman-echo.com/get?foo1=bar1";
-    let response = load_file(url).await?;
-    Ok(format!("Response payload: {} bytes", response.len()))
-}
-
-async fn app(_window: Window, mut events: EventStream) {
+async fn app(_window: Window, mut events: EventContext<MyEvent>) {
     
     // Kick off an inialization task, and block on its result
     
@@ -27,7 +25,7 @@ async fn app(_window: Window, mut events: EventStream) {
 
     loop {
         
-        while let Some(ev) = events.next_event().await {
+        while let Some(ev) = events.stream.next_event().await {
             println!("Got event: {:?}", ev)
             // Kick off a new task every time you press a certain key (maybe only one pending at once)
         }

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -1,0 +1,40 @@
+extern crate platter;
+
+use blinds::{run, Event, EventStream, Key, Settings, Window};
+
+use platter::load_file;
+use std::future::Future;
+use std::string::String;
+
+fn main() {
+    run(Settings::default(), app);
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn echo_request() -> Result<String> {
+    let url = "https://postman-echo.com/get?foo1=bar1";
+    let response = load_file(url).await?;
+    Ok(format!("Response payload: {} bytes", response.len()))
+}
+
+async fn app(_window: Window, mut events: EventStream) {
+    
+    // Kick off an inialization task, and block on its result
+    
+    // Setup a custom CustomEventStream<CustomEvent>
+    
+    // Kick off a loading task, and don't block
+
+    loop {
+        
+        while let Some(ev) = events.next_event().await {
+            println!("Got event: {:?}", ev)
+            // Kick off a new task every time you press a certain key (maybe only one pending at once)
+        }
+
+        // while let Some(ev) = custom_events.next_event().await {
+        //     println!("Got custom event: {:?}", ev)
+        // }
+        
+    }
+}

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -1,10 +1,12 @@
 extern crate platter;
 
 use blinds::{run_custom, Event as BlindsEvent, EventContext, Settings, Window};
+use platter::load_file;
 
 #[derive(Debug)]
 enum MyEvent {
-    Blinds(BlindsEvent)
+    Blinds(BlindsEvent),
+    AssetReady,
 }
 
 impl From<BlindsEvent> for MyEvent{
@@ -15,24 +17,35 @@ fn main() {
     run_custom(Settings::default(), app);
 }
 
-async fn app(_window: Window, mut events: EventContext<MyEvent>) {
-    
-    // Kick off an inialization task, and block on its result
-    
-    // Setup a custom CustomEventStream<CustomEvent>
+async fn load(context: EventContext<MyEvent>) {
+    let f = load_file("examples/non_blocking.rs").await;
+    println!("File ready: {:?}", f);
+    context.dispatch(MyEvent::AssetReady);
+}
+
+async fn app(_window: Window, mut context: EventContext<MyEvent>) {
     
     // Kick off a loading task, and don't block
+    context.spawn(load);
+
+    // TODO: I would really like to use a closure here. Uncomment, it fails
+
+    // context.clone().spawn(|inner_context: EventContext<MyEvent>| async {
+    //     let _ = load_file("examples/non_blocking.rs").await;
+    //     inner_context.clone().dispatch(MyEvent::AssetReady);
+    //     ()
+    // });
 
     loop {
         
-        while let Some(ev) = events.stream.next_event().await {
+        println!("Entering loop iteration");
+
+        while let Some(ev) = context.stream.next_event().await {
             println!("Got event: {:?}", ev)
             // Kick off a new task every time you press a certain key (maybe only one pending at once)
         }
 
-        // while let Some(ev) = custom_events.next_event().await {
-        //     println!("Got custom event: {:?}", ev)
-        // }
-        
+        println!("Ending loop iteration");
+
     }
 }

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -1,20 +1,24 @@
-extern crate platter;
 extern crate async_std;
+extern crate platter;
 
-use blinds::{run_custom, Event as BlindsEvent, EventContext, Settings, Window, Key};
-use platter::load_file;
 use async_std::task::sleep;
+use blinds::{run_custom, Event as BlindsEvent, EventContext, Key, Settings, Window};
+use platter::load_file;
+use std::io::Error as IOError;
 use std::time::Duration;
 
 #[derive(Debug)]
 enum MyEvent {
     Blinds(BlindsEvent),
-    AssetReady,
-    Tick,
+    AssetReady(Result<usize, IOError>),
+    Ticked,
+    Handled,
 }
 
-impl From<BlindsEvent> for MyEvent{
-    fn from(e: BlindsEvent) -> Self { MyEvent::Blinds(e) }
+impl From<BlindsEvent> for MyEvent {
+    fn from(e: BlindsEvent) -> Self {
+        MyEvent::Blinds(e)
+    }
 }
 
 fn main() {
@@ -25,37 +29,48 @@ async fn tick_loop(context: EventContext<MyEvent>) {
     // some sort of sleep would be nice
     loop {
         println!("Ticking");
-        (&context).dispatch(MyEvent::Tick);
+        (&context).dispatch(MyEvent::Ticked);
         sleep(Duration::from_secs(1)).await
     }
 }
 
-async fn app(window: Window, mut context: EventContext<MyEvent>) {
-    
+async fn button_handler(context: EventContext<MyEvent>) {
+    println!("Handling!");
+    (&context).dispatch(MyEvent::Handled);
+}
+
+async fn app(_window: Window, mut context: EventContext<MyEvent>) {
     // Start a long-running "background" task
     context.spawn(tick_loop);
 
-    // Start a task which completes
-    context.spawn(|inner_context: EventContext<MyEvent>| async move {
-        let _ = load_file("examples/non_blocking.rs").await;
-        inner_context.dispatch(MyEvent::AssetReady)
+    // Start a third-party async task, and notify a first-party event on completion
+    context.spawn(|inner_context: EventContext<MyEvent>| {
+        async move {
+            let result = load_file("examples/non_blocking.rs").await;
+            let content_length = result.map(|vec| vec.len());
+            inner_context.dispatch(MyEvent::AssetReady(content_length))
+        }
     });
 
     'outer: loop {
-        
-        while let Some(ev) = context.stream.next_event().await {
+        while let Some(ev) = context.stream().next_event().await {
             println!("Got event: {:?}", ev);
 
             if let MyEvent::Blinds(BlindsEvent::KeyboardInput {
                 key: Key::Escape, ..
             }) = ev
             {
-                // window.
+                // Exit the main loop, eventually causing the window to close and them program to terminate
                 break 'outer;
             }
 
-            // TODO: Kick off a new task every time you press a certain key (maybe only one pending at once)
+            if let MyEvent::Blinds(BlindsEvent::KeyboardInput {
+                key: Key::Space, ..
+            }) = ev
+            {
+                // Start a first-party
+                context.spawn(button_handler);
+            }
         }
-
     }
 }

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -1,12 +1,16 @@
 extern crate platter;
+extern crate async_std;
 
 use blinds::{run_custom, Event as BlindsEvent, EventContext, Settings, Window};
 use platter::load_file;
+use async_std::task::sleep;
+use std::time::Duration;
 
 #[derive(Debug)]
 enum MyEvent {
     Blinds(BlindsEvent),
     AssetReady,
+    Tick,
 }
 
 impl From<BlindsEvent> for MyEvent{
@@ -17,35 +21,32 @@ fn main() {
     run_custom(Settings::default(), app);
 }
 
-async fn load(context: EventContext<MyEvent>) {
-    let f = load_file("examples/non_blocking.rs").await;
-    println!("File ready: {:?}", f);
-    context.dispatch(MyEvent::AssetReady);
+async fn tick_loop(context: EventContext<MyEvent>) {
+    // some sort of sleep would be nice
+    loop {
+        println!("Ticking");
+        (&context).dispatch(MyEvent::Tick);
+        sleep(Duration::from_secs(1)).await
+    }
 }
 
 async fn app(_window: Window, mut context: EventContext<MyEvent>) {
     
-    // Kick off a loading task, and don't block
-    context.spawn(load);
+    // Start a long-running "background" task
+    context.spawn(tick_loop);
 
-    // TODO: I would really like to use a closure here. Uncomment, it fails
-
-    // context.clone().spawn(|inner_context: EventContext<MyEvent>| async {
-    //     let _ = load_file("examples/non_blocking.rs").await;
-    //     inner_context.clone().dispatch(MyEvent::AssetReady);
-    //     ()
-    // });
+    // Start a task which completes
+    context.spawn(|inner_context: EventContext<MyEvent>| async move {
+        let _ = load_file("examples/non_blocking.rs").await;
+        inner_context.dispatch(MyEvent::AssetReady)
+    });
 
     loop {
         
-        println!("Entering loop iteration");
-
         while let Some(ev) = context.stream.next_event().await {
             println!("Got event: {:?}", ev)
-            // Kick off a new task every time you press a certain key (maybe only one pending at once)
+            // TODO: Kick off a new task every time you press a certain key (maybe only one pending at once)
         }
-
-        println!("Ending loop iteration");
 
     }
 }

--- a/src/event_context.rs
+++ b/src/event_context.rs
@@ -1,9 +1,39 @@
 
 use crate::EventStream;
 use futures_executor::LocalSpawner;
+use std::future::Future;
+use futures_util::task::LocalSpawnExt;
 
 // FIXME: struct fields shouldn't be public
+// #[derive(Clone)]
 pub struct EventContext<E> {
     pub spawner: LocalSpawner,
     pub stream: EventStream<E>,
+}
+
+// All of these custom Clone are smelly
+impl <E> Clone for EventContext<E> {
+    fn clone(&self) -> Self {
+        EventContext {
+            spawner: self.spawner.clone(),
+            stream: self.stream.clone(),
+        }
+    }
+}
+
+// TODO: should probably start using Result more frquently?
+impl <'a, E> EventContext<E> {
+    pub fn spawn<F, T>(&'a self, task: F) 
+    where 
+        T: 'static + Future<Output = ()>,
+        F: 'static + FnOnce(EventContext<E>) -> T {
+            let context_copy: EventContext<E> = self.clone();
+            self.spawner
+            .spawn_local(task(context_copy))
+            .expect("Failed to start application");
+    }
+
+    pub fn dispatch(&'a self, event: E) {
+        self.stream.buffer().borrow_mut().push(event)
+    }
 }

--- a/src/event_context.rs
+++ b/src/event_context.rs
@@ -1,0 +1,9 @@
+
+use crate::EventStream;
+use futures_executor::LocalSpawner;
+
+// FIXME: struct fields shouldn't be public
+pub struct EventContext<E> {
+    pub spawner: LocalSpawner,
+    pub stream: EventStream<E>,
+}

--- a/src/event_context.rs
+++ b/src/event_context.rs
@@ -3,7 +3,6 @@ use futures_executor::LocalSpawner;
 use futures_util::task::LocalSpawnExt;
 use std::future::Future;
 
-// FIXME: struct fields shouldn't be public
 // #[derive(Clone)]
 pub struct EventContext<E> {
     spawner: LocalSpawner,
@@ -20,14 +19,12 @@ impl<E> Clone for EventContext<E> {
     }
 }
 
-// TODO: should probably start using Result more frquently?
-// is the explicit lifetime parameter necessary here?
-impl<'a, E> EventContext<E> {
+impl<E> EventContext<E> {
     pub fn new(spawner: LocalSpawner, stream: EventStream<E>) -> Self {
         EventContext { spawner, stream }
     }
 
-    pub fn spawn<F, T>(&'a self, task: F)
+    pub fn spawn<F, T>(&self, task: F)
     where
         T: 'static + Future<Output = ()>,
         F: 'static + FnOnce(EventContext<E>) -> T,
@@ -42,7 +39,7 @@ impl<'a, E> EventContext<E> {
         &mut self.stream
     }
 
-    pub fn dispatch(&'a self, event: E) {
+    pub fn dispatch(&self, event: E) {
         self.stream.buffer().borrow_mut().push(event)
     }
 }

--- a/src/event_context.rs
+++ b/src/event_context.rs
@@ -1,18 +1,17 @@
-
 use crate::EventStream;
 use futures_executor::LocalSpawner;
-use std::future::Future;
 use futures_util::task::LocalSpawnExt;
+use std::future::Future;
 
 // FIXME: struct fields shouldn't be public
 // #[derive(Clone)]
 pub struct EventContext<E> {
-    pub spawner: LocalSpawner,
-    pub stream: EventStream<E>,
+    spawner: LocalSpawner,
+    stream: EventStream<E>,
 }
 
 // All of these custom Clone are smelly
-impl <E> Clone for EventContext<E> {
+impl<E> Clone for EventContext<E> {
     fn clone(&self) -> Self {
         EventContext {
             spawner: self.spawner.clone(),
@@ -22,15 +21,25 @@ impl <E> Clone for EventContext<E> {
 }
 
 // TODO: should probably start using Result more frquently?
-impl <'a, E> EventContext<E> {
-    pub fn spawn<F, T>(&'a self, task: F) 
-    where 
+// is the explicit lifetime parameter necessary here?
+impl<'a, E> EventContext<E> {
+    pub fn new(spawner: LocalSpawner, stream: EventStream<E>) -> Self {
+        EventContext { spawner, stream }
+    }
+
+    pub fn spawn<F, T>(&'a self, task: F)
+    where
         T: 'static + Future<Output = ()>,
-        F: 'static + FnOnce(EventContext<E>) -> T {
-            let context_copy: EventContext<E> = self.clone();
-            self.spawner
+        F: 'static + FnOnce(EventContext<E>) -> T,
+    {
+        let context_copy: EventContext<E> = self.clone();
+        self.spawner
             .spawn_local(task(context_copy))
             .expect("Failed to start application");
+    }
+
+    pub fn stream(&mut self) -> &mut EventStream<E> {
+        &mut self.stream
     }
 
     pub fn dispatch(&'a self, event: E) {

--- a/src/event_stream.rs
+++ b/src/event_stream.rs
@@ -1,4 +1,3 @@
-
 use futures_util::future::poll_fn;
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -21,7 +20,9 @@ pub struct EventStream<E> {
 // All of these custom Clone are smelly
 impl<E> Clone for EventStream<E> {
     fn clone(&self) -> Self {
-        EventStream { buffer: self.buffer() }
+        EventStream {
+            buffer: self.buffer(),
+        }
     }
 }
 
@@ -73,7 +74,7 @@ pub(crate) struct EventBuffer<E> {
     ready: bool,
 }
 
-impl <E> EventBuffer<E> {
+impl<E> EventBuffer<E> {
     pub fn push(&mut self, event: E) {
         self.events.push_back(event);
         self.mark_ready();

--- a/src/event_stream.rs
+++ b/src/event_stream.rs
@@ -18,6 +18,13 @@ pub struct EventStream<E> {
     buffer: Arc<RefCell<EventBuffer<E>>>,
 }
 
+// All of these custom Clone are smelly
+impl<E> Clone for EventStream<E> {
+    fn clone(&self) -> Self {
+        EventStream { buffer: self.buffer() }
+    }
+}
+
 impl<E> EventStream<E> {
     pub(crate) fn new() -> Self {
         EventStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! run(Settings::default(), app);
 //!
-//! async fn app(_window: Window, mut events: EventStream) {
+//! async fn app(_window: Window, mut events: EventStream<Event>) {
 //!     loop {
 //!         while let Some(ev) = events.next_event().await {
 //!             println!("{:?}", ev);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! [`Window`]: Window
 //! [`EventStream`]: EventStream
 mod event;
+mod event_context;
 mod event_stream;
 mod run;
 mod window;
@@ -30,8 +31,9 @@ pub use self::event::{
     ElementState, Event, GamepadAxis, GamepadButton, GamepadEvent, GamepadId, Key, Modifiers,
     MouseButton, MouseScrollDelta, Pointer,
 };
+pub use self::event_context::EventContext;
 pub use self::event_stream::EventStream;
-pub use self::run::run;
+pub use self::run::{run, run_custom};
 pub use self::window::{CursorIcon, Settings, Window};
 
 #[cfg(feature = "gl")]

--- a/src/run.rs
+++ b/src/run.rs
@@ -134,6 +134,10 @@ fn do_run<E>(
             _ => (),
         }
         if finished {
+            // This is a bug; now that I've spawned other stuff, when one of those
+            // other tasks finishes, blinds thinks that the main loop exited. I will
+            // need to check ~which~ task completed, or something
+            println!("finished...");
             *ctrl = ControlFlow::Exit;
         }
     })

--- a/src/run.rs
+++ b/src/run.rs
@@ -33,6 +33,7 @@ where
     let event_loop = EventLoop::new();
     let window = Arc::new(WindowContents::new(&event_loop, settings));
 
+    // FIXME these next few lines here are not DRY; refactor?
     let finished = Arc::new(RefCell::new(false));
     let app_notify = || {
         let window = window.clone();
@@ -52,6 +53,7 @@ where
 }
 
 // Prototype entry point supporting custom events and tasks
+// TODO: public function needs documentation
 pub fn run_custom<F, T, E>(settings: Settings, app: F) -> !
 where
     T: 'static + Future<Output = ()>,
@@ -138,6 +140,7 @@ where
     #[cfg(feature = "gilrs")]
     let mut gilrs = gilrs::Gilrs::new();
 
+    // Would it be better to use run_until_stalled here?
     pool.try_run_one();
 
     event_loop.run(move |event, _, ctrl| {
@@ -165,6 +168,7 @@ where
                 buffer.borrow_mut().mark_ready();
                 #[cfg(feature = "gilrs")]
                 process_gilrs_events(&mut gilrs, &buffer);
+                // Would it be better to use run_until_stalled here?
                 pool.try_run_one();
             }
             _ => (),

--- a/src/run.rs
+++ b/src/run.rs
@@ -133,13 +133,13 @@ fn do_run<E>(
             }
             _ => (),
         }
-        if finished {
-            // This is a bug; now that I've spawned other stuff, when one of those
-            // other tasks finishes, blinds thinks that the main loop exited. I will
-            // need to check ~which~ task completed, or something
-            println!("finished...");
-            *ctrl = ControlFlow::Exit;
-        }
+        // if finished {
+        //     // This is a bug; now that I've spawned other stuff, when one of those
+        //     // other tasks finishes, blinds thinks that the main loop exited. I will
+        //     // need to check ~which~ task completed, or something
+        //     println!("finished...");
+        //     *ctrl = ControlFlow::Exit;
+        // }
     })
 }
 


### PR DESCRIPTION
So in response to #10, this is how I propose to reorganize the API to support non-blocking.

- Refactors `EventBuffer`/`EventStream` containers to operate on any event type.
- Introduces `EventContext` (naming? TaskContext?) which exposes the following new methods
  - `spawn` schedules a new task to run on the single blinds event loop
  - `dispatch` enqueues a new event to the single blinds event stream
- Usage demonstration in the "non_blocking" example

The alternatives considered would have users of blinds manage their own event loop. In my opinion, that's pretty complex to manage, and it's not sure where in an app they would be expected to manage that sort of resource. Instead, here we delegate the complexity to the system and introduce limited task capabilities. 

Pros: Keeps user "on the rails" by not exposing a callback-hell style concurrency API
Cons: More type parameters, more API surface area, possibility to starve the event loop with a non-cooperative task other than the main application loop (no preemptive scheduling).