### PR TITLE
Demonstrate "user" tasks with FuturesUnordered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,5 @@ simple_logger = "1.4"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 web_logger = "0.2"
+js-sys = "*"
+wasm-bindgen-futures = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,17 @@ webgl_stdweb = { version = "0.3.0", optional = true }
 web_sys = { version = "0.3.22", package = "web-sys", optional = true, features = ["HtmlHeadElement"] }
 winit = "0.20.0"
 
+[dev-dependencies]
+instant = "*"
+futures-core = "*"
+log = "*"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.22", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+async-std = "*"
+simple_logger = "1.4"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+web_logger = "0.2"

--- a/examples/custom_task.rs
+++ b/examples/custom_task.rs
@@ -1,0 +1,186 @@
+
+// use async_std::task::sleep;
+use blinds::{run, EventStream, Event as BlindsEvent, Settings, Window};
+use futures_util::task::LocalSpawnExt;
+use futures_core::stream::Stream;
+use futures_util::stream::FuturesUnordered;
+use std::sync::Arc;
+use std::cell::RefCell;
+use std::pin::Pin;
+use futures_util::future::{poll_fn, pending};
+use futures_util::future::{select_all, FutureExt};
+use std::collections::VecDeque;
+use std::future::Future;
+use std::task::{Poll, Waker};
+use futures_util::future::LocalFutureObj;
+use log::info;
+
+fn set_logger() {
+    #[cfg(target_arch = "wasm32")]
+    web_logger::custom_init(web_logger::Config {
+        level: log::Level::Debug,
+    });
+    #[cfg(not(target_arch = "wasm32"))]
+    simple_logger::init_with_level(log::Level::Debug).expect("A logger was already initialized");
+}
+
+fn main() {
+    set_logger();
+    run(Settings::default(), app);
+}
+
+#[derive(Debug)]
+enum CustomEvent {
+    Ticked
+}
+
+#[derive(Debug)]
+enum LocalEvent {
+    Blinds(BlindsEvent),
+    Custom(CustomEvent),
+    TaskFinished
+}
+
+/**
+ * Bugs!
+ * 
+ * #1 Without a real sleep/timer/alarm, the tick_loop is "uncooperative" and doesn't suspend
+ * #2 Without any tasks running, polling the FuturedUnordered is always Ready. Need to use a waker.
+ */
+
+#[cfg(not(target_arch = "wasm32"))]
+mod sleep {
+    use async_std::task::sleep;
+    use std::time::Duration;
+    
+    pub async fn sleep_1() { sleep(Duration::from_secs(1)).await }
+}
+
+
+#[cfg(all(feature = "stdweb", target_arch = "wasm32"))]
+mod sleep {
+    use futures_util::future::pending;
+    pub async fn sleep_1() { pending().await }
+}
+
+#[cfg(all(feature = "web-sys", target_arch = "wasm32"))]
+mod sleep {
+    use futures_util::future::pending;
+    pub async fn sleep_1() { pending().await }
+}
+
+async fn tick_loop(local_events: Arc<RefCell<MyEventBuffer<CustomEvent>>>)  {
+    loop {
+        local_events.borrow_mut().push(CustomEvent::Ticked);
+        sleep::sleep_1().await
+    }
+}
+
+async fn next_event(mut event_stream: EventStream) -> LocalEvent {
+    LocalEvent::Blinds(event_stream.next_event_blocking().await)
+}
+
+async fn next_finished_task<Fut>(futures_cell: Arc<RefCell<FuturesUnordered<Fut>>>) -> LocalEvent where Fut: Future<Output = ()>  {
+    let futures_cell = futures_cell.clone();
+    poll_fn(move |cx| {
+        let mut x = futures_cell.borrow_mut();
+        let pinned_pool = Pin::new(&mut *x);
+        let poll_result = pinned_pool.poll_next(cx);
+        poll_result
+    }).await;
+    LocalEvent::TaskFinished
+}
+
+async fn app(_window: Window, event_stream: EventStream) {
+    // Setup all of the crap
+    let mut local_events: MyEventStream<CustomEvent> = MyEventStream::new();
+    let futures_pool: FuturesUnordered<LocalFutureObj<()>> = FuturesUnordered::new();
+    let futures_cell = Arc::new(RefCell::new(futures_pool));
+
+    // Spawn a never-ending task to keep the future pool from spinning freely. Hack for bug #2
+    futures_cell.borrow().spawn_local(pending()).expect("Failed to start pending task");
+
+    // Spawn the loop task
+    // !!! Disabled because it needs to go into Pending somehow !!!
+    futures_cell.borrow().spawn_local(tick_loop(local_events.buffer())).expect("Failed to start tick loop");
+
+    'main: loop {
+        // Define all of the possible futures (now all same type)
+        let task = next_finished_task(futures_cell.clone()).boxed_local();
+        let blinds = next_event(event_stream.clone()).boxed_local();
+        let local = local_events.next_event_blocking().map(|ev| LocalEvent::Custom(ev)).boxed_local();
+
+        // Wait for the first one
+        let (ev, _index, _remaining) = select_all(vec!(task, blinds, local)).await;
+
+        // Switch
+        match ev {
+            LocalEvent::Blinds(ev) => info!("Blinds Event {:?}", ev),
+            LocalEvent::Custom(ev) => info!("Custom Event {:?}", ev),
+            LocalEvent::TaskFinished => info!("Task finished")
+        }
+    }
+}
+
+/**
+ * Everything below here is a copy of something already in the repository, but made generic
+ */
+
+// #[derive(Clone)]
+pub struct MyEventStream<E> {
+    buffer: Arc<RefCell<MyEventBuffer<E>>>,
+}
+
+impl <E> MyEventStream<E> {
+    pub(crate) fn new() -> Self {
+        MyEventStream {
+            buffer: Arc::new(RefCell::new(MyEventBuffer {
+                events: VecDeque::new(),
+                waker: None,
+                ready: false,
+            })),
+        }
+    }
+
+    pub(crate) fn buffer(&self) -> Arc<RefCell<MyEventBuffer<E>>> {
+        self.buffer.clone()
+    }
+
+    // FIXME: change the type 
+    pub fn next_event_blocking<'a>(&'a mut self) -> impl 'a + Future<Output = E> {
+        poll_fn(move |cx| {
+            let mut buffer = self.buffer.borrow_mut();
+            match buffer.events.pop_front() {
+                Some(event) => Poll::Ready(event),
+                None => {
+                    if buffer.ready {
+                        buffer.ready = false
+                    }
+                    buffer.waker = Some(cx.waker().clone());
+                    Poll::Pending
+                }
+            }
+        })
+    }
+}
+
+// #[derive(Clone)]
+pub(crate) struct MyEventBuffer<E> {
+    events: VecDeque<E>,
+    waker: Option<Waker>,
+    ready: bool,
+}
+
+impl <E> MyEventBuffer<E> {
+    pub fn push(&mut self, event: E) {
+        self.events.push_back(event);
+        self.mark_ready();
+    }
+
+    pub fn mark_ready(&mut self) {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+        self.ready = true;
+    }
+}

--- a/src/event_stream.rs
+++ b/src/event_stream.rs
@@ -20,13 +20,13 @@ pub struct EventStream {
 }
 
 impl Clone for EventStream {
-    fn clone(&self) -> Self {
-        EventStream { buffer : self.buffer() }
+    fn clone(&self) -> Self { 
+        EventStream { buffer: self.buffer() } 
     }
 }
 
 impl EventStream {
-    pub(crate) fn new() -> EventStream {
+    pub(crate) fn new() -> Self {
         EventStream {
             buffer: Arc::new(RefCell::new(EventBuffer {
                 events: VecDeque::new(),
@@ -61,23 +61,6 @@ impl EventStream {
                         buffer.waker = Some(cx.waker().clone());
                         Poll::Pending
                     }
-                }
-            }
-        })
-    }
-
-    // FIXME: change the type 
-    pub fn next_event_blocking<'a>(&'a mut self) -> impl 'a + Future<Output = Event> {
-        poll_fn(move |cx| {
-            let mut buffer = self.buffer.borrow_mut();
-            match buffer.events.pop_front() {
-                Some(event) => Poll::Ready(event),
-                None => {
-                    if buffer.ready {
-                        buffer.ready = false
-                    }
-                    buffer.waker = Some(cx.waker().clone());
-                    Poll::Pending
                 }
             }
         })

--- a/src/event_stream.rs
+++ b/src/event_stream.rs
@@ -19,12 +19,6 @@ pub struct EventStream {
     buffer: Arc<RefCell<EventBuffer>>,
 }
 
-impl Clone for EventStream {
-    fn clone(&self) -> Self { 
-        EventStream { buffer: self.buffer() } 
-    }
-}
-
 impl EventStream {
     pub(crate) fn new() -> Self {
         EventStream {

--- a/src/event_stream.rs
+++ b/src/event_stream.rs
@@ -19,6 +19,12 @@ pub struct EventStream {
     buffer: Arc<RefCell<EventBuffer>>,
 }
 
+impl Clone for EventStream {
+    fn clone(&self) -> Self {
+        EventStream { buffer : self.buffer() }
+    }
+}
+
 impl EventStream {
     pub(crate) fn new() -> EventStream {
         EventStream {
@@ -55,6 +61,23 @@ impl EventStream {
                         buffer.waker = Some(cx.waker().clone());
                         Poll::Pending
                     }
+                }
+            }
+        })
+    }
+
+    // FIXME: change the type 
+    pub fn next_event_blocking<'a>(&'a mut self) -> impl 'a + Future<Output = Event> {
+        poll_fn(move |cx| {
+            let mut buffer = self.buffer.borrow_mut();
+            match buffer.events.pop_front() {
+                Some(event) => Poll::Ready(event),
+                None => {
+                    if buffer.ready {
+                        buffer.ready = false
+                    }
+                    buffer.waker = Some(cx.waker().clone());
+                    Poll::Pending
                 }
             }
         })


### PR DESCRIPTION
This is definitely not quite ready, but demonstrates a few things.

* Spawning the tick loop and having it communicate with the main loop via events allows it to be written in an imperative style.
* It's handy to have a blocking version of the blinds EventStream (one that doesn't return Option) but I might just be doing that wrong?
* I need to have a poll-&-wake-up version of the FuturesUnordered

Overall though this example convinces me that the blinds event loop can remained "sealed", there's plenty in the async/futures space to do complex things.

TODO

* Fix the bugs
* Implement real sleep methods for stdweb, and possible also web_sys

It's a pretty heavy example too, lots of bells & whitelist, might be overkill.