### PR TITLE
Logical pointer

### DIFF
--- a/src/event/convert.rs
+++ b/src/event/convert.rs
@@ -1,7 +1,8 @@
 use super::*;
+use crate::window::WindowContents;
 use winit::event::{DeviceEvent, ElementState, WindowEvent};
 
-pub(crate) fn window_event(event: WindowEvent) -> Option<Event> {
+pub(crate) fn window_event(event: WindowEvent, window: &WindowContents) -> Option<Event> {
     use WindowEvent::*;
     Some(match event {
         Resized(ls) => Event::Resized(ResizedEvent {
@@ -32,7 +33,7 @@ pub(crate) fn window_event(event: WindowEvent) -> Option<Event> {
             ..
         } => Event::PointerMoved(PointerMovedEvent {
             id: PointerId(device_id),
-            location: pp_to_vec(position),
+            location: pp_to_logical_vec(position, window.scale()),
         }),
         CursorEntered { device_id, .. } => {
             Event::PointerEntered(PointerEnteredEvent(PointerId(device_id)))
@@ -113,9 +114,9 @@ fn ps_to_vec<P: winit::dpi::Pixel>(ls: winit::dpi::PhysicalSize<P>) -> Vector2<f
     }
 }
 
-fn pp_to_vec<P: winit::dpi::Pixel>(ls: winit::dpi::PhysicalPosition<P>) -> Vector2<f32> {
+fn pp_to_logical_vec<P: winit::dpi::Pixel>(ls: winit::dpi::PhysicalPosition<P>, scale: f32) -> Vector2<f32> {
     Vector2 {
-        x: ls.x.cast(),
-        y: ls.y.cast(),
+        x: ls.x.cast::<f32>() / scale,
+        y: ls.y.cast::<f32>() / scale,
     }
 }

--- a/src/event/convert.rs
+++ b/src/event/convert.rs
@@ -114,7 +114,10 @@ fn ps_to_vec<P: winit::dpi::Pixel>(ls: winit::dpi::PhysicalSize<P>) -> Vector2<f
     }
 }
 
-fn pp_to_logical_vec<P: winit::dpi::Pixel>(ls: winit::dpi::PhysicalPosition<P>, scale: f32) -> Vector2<f32> {
+fn pp_to_logical_vec<P: winit::dpi::Pixel>(
+    ls: winit::dpi::PhysicalPosition<P>,
+    scale: f32,
+) -> Vector2<f32> {
     Vector2 {
         x: ls.x.cast::<f32>() / scale,
         y: ls.y.cast::<f32>() / scale,

--- a/src/run.rs
+++ b/src/run.rs
@@ -91,14 +91,7 @@ fn do_run(
                 if let winit::event::WindowEvent::Resized(size) = &event {
                     window.resize(*size);
                 }
-                if let Some(mut event) = window_event(event) {
-                    if let Event::PointerMoved(e) = &mut event {
-                        let recip = 1.0 / window.scale();
-                        e.location = mint::Vector2 {
-                            x: e.location.x * recip,
-                            y: e.location.y * recip,
-                        };
-                    }
+                if let Some(event) = window_event(event, &window) {
                     buffer.borrow_mut().push(event);
                 }
             }

--- a/src/run.rs
+++ b/src/run.rs
@@ -91,7 +91,14 @@ fn do_run(
                 if let winit::event::WindowEvent::Resized(size) = &event {
                     window.resize(*size);
                 }
-                if let Some(event) = window_event(event) {
+                if let Some(mut event) = window_event(event) {
+                    if let Event::PointerMoved(e) = &mut event {
+                        let recip = 1.0 / window.scale();
+                        e.location = mint::Vector2 {
+                            x: e.location.x * recip,
+                            y: e.location.y * recip,
+                        };
+                    }
                     buffer.borrow_mut().push(event);
                 }
             }


### PR DESCRIPTION
In the first commit I opted to simply hijack the event and convert the coordinates directly in `src/run.rs`, before the events were sent through the buffer. However, after thinking it over a bit I opted instead to do the conversion in `src/event/convert.rs`, so that the locations would be converted as soon as they were received from `winit`, even though this required also passing `&WindowContents` as a parameter to `events::convert::window_event()`. Having this code in `convert.rs` made more organizational sense to me, since converting from physical to logical positions is, after all, a conversion.

After I did that, I considered that since the `Resized` event was being hijacked in `run.rs` as well, perhaps it would benefit from being moved into `convert.rs`, but I opted not to do that since the event was being hijacked in order to mutate the `WindowContents`, which isn't really a conversion and therefore doesn't belong in `events::convert::window_event()`.