### PR TITLE
Fix canvas properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.1.5
+- Fix alpha-blending settings on the web
+
 ## v0.1.4
 - Add Clone, PartialEq derivations to Settings
 - Add Copy, Clone, PartialEq, Eq, Hash to CursorIcon

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ favicon = ["image"]
 gamepad = ["gilrs"]
 gl = ["glow", "glutin"]
 stdweb = ["std_web", "webgl_stdweb", "winit/stdweb", "glow/stdweb"]
-web-sys = ["wasm-bindgen", "web_sys", "winit/web-sys", "glow/web-sys"]
+web-sys = ["js-sys", "wasm-bindgen", "web_sys", "winit/web-sys", "glow/web-sys"]
 
 [dependencies]
 enum-map = { version = "0.6.2", default-features = false, optional = true }
@@ -36,6 +36,7 @@ std_web = { version = "0.4.20", package = "stdweb", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 webgl_stdweb = { version = "0.3.0", optional = true }
 web_sys = { version = "0.3.22", package = "web-sys", optional = true, features = ["HtmlHeadElement"] }
+js-sys = { version = "0.3.22", optional = true }
 winit = "0.22.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/window.rs
+++ b/src/window.rs
@@ -168,24 +168,33 @@ impl WindowContents {
         let ctx = {
             #[cfg(feature = "stdweb")]
             let ctx = {
-                use webgl_stdweb::WebGLRenderingContext;
+                use std_web::js;
+                use std_web::unstable::TryInto;
+
                 use winit::platform::web::WindowExtStdweb;
 
-                window
-                    .window
-                    .canvas()
-                    .get_context::<WebGLRenderingContext>()
-                    .expect("Failed to acquire a WebGL rendering context")
+                let canvas = window.window.canvas();
+                js! (
+                    return @{canvas}.getContext("webgl", {
+                        alpha: false,
+                        premultipliedAlpha: false,
+                    });
+                ).into_reference().unwrap().try_into().unwrap()
             };
             #[cfg(feature = "web-sys")]
             let ctx = {
-                use wasm_bindgen::JsCast;
+                use wasm_bindgen::{JsCast, JsValue};
+                use js_sys::{Map, Object};
                 use winit::platform::web::WindowExtWebSys;
+                let map = Map::new();
+                map.set(&JsValue::from_str("premultipliedAlpha"), &JsValue::FALSE);
+                map.set(&JsValue::from_str("alpha"), &JsValue::FALSE);
+                let props = Object::from_entries(&map).expect("TODO");
 
                 window
                     .window
                     .canvas()
-                    .get_context("webgl")
+                    .get_context_with_context_options("webgl", &props)
                     .expect("Failed to acquire a WebGL rendering context")
                     .expect("Failed to acquire a WebGL rendering context")
                     .dyn_into::<web_sys::WebGlRenderingContext>()

--- a/src/window.rs
+++ b/src/window.rs
@@ -179,12 +179,16 @@ impl WindowContents {
                         alpha: false,
                         premultipliedAlpha: false,
                     });
-                ).into_reference().unwrap().try_into().unwrap()
+                )
+                .into_reference()
+                .unwrap()
+                .try_into()
+                .unwrap()
             };
             #[cfg(feature = "web-sys")]
             let ctx = {
-                use wasm_bindgen::{JsCast, JsValue};
                 use js_sys::{Map, Object};
+                use wasm_bindgen::{JsCast, JsValue};
                 use winit::platform::web::WindowExtWebSys;
                 let map = Map::new();
                 map.set(&JsValue::from_str("premultipliedAlpha"), &JsValue::FALSE);


### PR DESCRIPTION
On the web, 'premultipliedAlpha' is true by default.
This causes a bug downstream in Quicksilver, because by default on
desktop alphas are not premultiplied.