### PR TITLE
Auto-focus the canvas when opening on web

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -20,11 +20,11 @@ pub struct Settings {
     pub multisampling: Option<u16>,
     /// Enable or disable vertical sync
     ///
-    /// Does nothing on web
+    /// Does nothing on web; defaults to true
     pub vsync: bool,
     /// If the window can be resized by the user
     ///
-    /// Does nothing on web
+    /// Does nothing on web; defaults to false
     pub resizable: bool,
     /// The title of your application
     pub title: &'static str,

--- a/src/window.rs
+++ b/src/window.rs
@@ -44,6 +44,8 @@ fn insert_canvas(
         .expect("Document has no body node")
         .append_child(&canvas);
 
+    canvas.focus();
+
     #[cfg(feature = "favicon")]
     {
         if let Some(path) = _settings.icon_path {
@@ -79,6 +81,8 @@ fn insert_canvas(window: &WinitWindow, _settings: &Settings) -> web_sys::HtmlCan
         .expect("Document has no body node")
         .append_child(&canvas)
         .expect("Failed to insert canvas");
+
+    canvas.focus();
 
     #[cfg(feature = "favicon")]
     {


### PR DESCRIPTION
This should solve the problem described in ryanisaacg/quicksilver#565. Winit's default web behavior is to let the user decide when to focus on the canvas, but blinds can be more specific than that. Blinds expects that is the only game in its frame, so it grabbing focus improves the user experience without sacrificing much flexibility.