### PR TITLE
Remove stdweb support and reshape the GL interface

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,22 +32,19 @@ jobs:
       run: sudo apt update && sudo apt install libudev-dev
     - uses: actions/checkout@master
     - name: Test
-      run: cargo test ${{ matrix.options }} --examples
+      run: cargo test --examples
     - name: Test With Event Cache
-      run: cargo test ${{ matrix.options }} --examples --features event-cache
-    - name: Test With GL
-      run: cargo test ${{ matrix.options }} --examples --features gl
+      run: cargo test --examples --all-features
 
   clippy:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:
-        rust-version: ${{ matrix.rust }}
+        rust-version: stable
         components: clippy
     - name: Install libudev
       if: matrix.os == 'ubuntu-latest'
@@ -56,19 +53,17 @@ jobs:
     - name: Clippy
       run: cargo clippy -- -D warnings
     - name: Clippy with features
-      run: cargo clippy --features gl,event-cache -- -D warnings
+      run: cargo clippy --all-features -- -D warnings
 
   clippy-web:
     runs-on: macOS-latest
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:
-        rust-version: ${{ matrix.rust }}
+        rust-version: stable
         targets: wasm32-unknown-unknown
     - uses: actions/checkout@master
-    - name: Check stdweb
-      run: cargo install cargo-web && cargo web check --features stdweb
-    - name: Check
-      run: cargo check --target wasm32-unknown-unknown --features web-sys
+    - name: Check web
+      run: cargo check --target wasm32-unknown-unknown
     - name: Check with features
-      run: cargo check --target wasm32-unknown-unknown --features web-sys,event-cache,gl 
+      run: cargo check --target wasm32-unknown-unknown --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,28 +19,25 @@ default = ["favicon", "gamepad"]
 event-cache = ["enum-map", "rustc-hash"]
 favicon = ["image"]
 gamepad = ["gilrs"]
-gl = ["glow", "glutin"]
-stdweb = ["std_web", "webgl_stdweb", "winit/stdweb", "glow/stdweb"]
-web-sys = ["js-sys", "wasm-bindgen", "web_sys", "winit/web-sys", "glow/web-sys"]
 
 [dependencies]
 enum-map = { version = "0.6.2", default-features = false, optional = true }
 futures-util = { version = "0.3.1", default-features = false }
 futures-executor = { version = "0.3.1", default-features = false, features = ["std"] }
-glow = { version = "0.4.0", default-features = false, optional = true }
 gilrs = { version = "0.7", optional = true }
 image = { version = "0.22.3", optional = true, default-features = false }
 mint = "0.5"
 rustc-hash = { version = "1.0", optional = true }
-std_web = { version = "0.4.20", package = "stdweb", optional = true }
-wasm-bindgen = { version = "0.2", optional = true }
-webgl_stdweb = { version = "0.3.0", optional = true }
-web_sys = { version = "0.3.22", package = "web-sys", optional = true, features = ["HtmlHeadElement"] }
-js-sys = { version = "0.3.22", optional = true }
-winit = "0.22.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = { version = "0.24", optional = true }
+glutin = "0.24"
+winit = "0.22.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.22"
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3.22", features = ["HtmlHeadElement", "WebGlRenderingContext"] }
+winit = { version = "0.22.0", features = ["web-sys"] }
 
 [[example]]
 name = "cache"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,5 @@ pub use self::run::run;
 pub use self::settings::{CursorIcon, Settings};
 pub use self::window::Window;
 
-#[cfg(feature = "gl")]
-pub use self::run::run_gl;
-
 pub(crate) use self::event_stream::EventBuffer;
 pub(crate) use self::window::WindowContents;

--- a/src/run.rs
+++ b/src/run.rs
@@ -11,7 +11,7 @@ use winit::event_loop::{ControlFlow, EventLoop};
 /// The entry point for a blinds-based application
 ///
 /// `run` acts as the executor for your async application, and it handles your event loop on both
-/// desktop and web. It is a single-threaded executor, because wasm doesn't support multithreading 
+/// desktop and web. It is a single-threaded executor, because wasm doesn't support multithreading
 /// at the moment.
 ///
 /// Currently blinds only supports one window, and `settings` determines how it will be

--- a/src/run.rs
+++ b/src/run.rs
@@ -11,16 +11,11 @@ use winit::event_loop::{ControlFlow, EventLoop};
 /// The entry point for a blinds-based application
 ///
 /// `run` acts as the executor for your async application, and it handles your event loop on both
-/// desktop and web. It is a single-threaded executor, because wasm doesn't support thread at the
-/// moment.
+/// desktop and web. It is a single-threaded executor, because wasm doesn't support multithreading 
+/// at the moment.
 ///
 /// Currently blinds only supports one window, and `settings` determines how it will be
 /// constructed.
-///
-/// If you want a GL context, use [`run_gl`] instead. GL contexts require additional work when
-/// creating a window, and therefore are not created by defualt.
-///
-/// [`run_gl`]: run_gl
 pub fn run<F, T>(settings: Settings, app: F) -> !
 where
     T: 'static + Future<Output = ()>,
@@ -34,35 +29,6 @@ where
     let pool = LocalPool::new();
     pool.spawner()
         .spawn_local(app(Window(window.clone()), stream))
-        .expect("Failed to start application");
-
-    do_run(event_loop, window, pool, buffer)
-}
-
-#[cfg(feature = "gl")]
-use glow::Context;
-
-#[cfg(feature = "gl")]
-/// The entry point for a blinds-based application using OpenGL
-///
-/// `run_gl` acts the same as [`run`] except it provides a [`glow`] context
-///
-/// [`run`]: run
-/// [`glow`]: glow
-pub fn run_gl<T, F>(settings: Settings, app: F) -> !
-where
-    T: 'static + Future<Output = ()>,
-    F: 'static + FnOnce(Window, Context, EventStream) -> T,
-{
-    let stream = EventStream::new();
-    let buffer = stream.buffer();
-
-    let event_loop = EventLoop::new();
-    let (window, ctx) = WindowContents::new_gl(&event_loop, settings);
-    let window = Arc::new(window);
-    let pool = LocalPool::new();
-    pool.spawner()
-        .spawn_local(app(Window(window.clone()), ctx, stream))
         .expect("Failed to start application");
 
     do_run(event_loop, window, pool, buffer)

--- a/src/window.rs
+++ b/src/window.rs
@@ -117,7 +117,7 @@ impl WindowContents {
 
         window
     }
-  
+
     fn set_cursor_icon(&self, icon: Option<CursorIcon>) {
         match icon {
             Some(icon) => {
@@ -146,7 +146,7 @@ impl WindowContents {
         #[cfg(not(target_arch = "wasm32"))]
         self.window.resize(_size);
     }
-    
+
     pub(crate) fn scale(&self) -> f32 {
         self.window().scale_factor() as f32
     }
@@ -218,13 +218,13 @@ impl Window {
             self.0.window().current_monitor(),
         ));
     }
-    
+
     #[cfg(not(target_arch = "wasm32"))]
     /// Return the address of a given OpenGL function
     pub fn get_proc_address(&self, func: &str) -> *const core::ffi::c_void {
         self.0.window.get_proc_address(func)
     }
-        
+
     #[cfg(target_arch = "wasm32")]
     /// Create a WebGL context from the backing canvas
     pub fn webgl_context(&self) -> web_sys::WebGlRenderingContext {
@@ -236,7 +236,8 @@ impl Window {
         map.set(&JsValue::from_str("alpha"), &JsValue::FALSE);
         let props = Object::from_entries(&map).expect("Failed to create object");
 
-        self.0.window
+        self.0
+            .window
             .canvas()
             .get_context_with_context_options("webgl", &props)
             .expect("Failed to acquire a WebGL rendering context")
@@ -252,7 +253,10 @@ impl Window {
     /// no-op.
     pub fn present(&self) {
         #[cfg(not(target_arch = "wasm32"))]
-        self.0.window.swap_buffers().expect("Failed to swap buffers")
+        self.0
+            .window
+            .swap_buffers()
+            .expect("Failed to swap buffers")
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,7 +1,5 @@
 use crate::{CursorIcon, Settings};
-#[cfg(feature = "gl")]
-use glow::Context;
-#[cfg(all(feature = "gl", not(target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 use glutin::{PossiblyCurrent, WindowedContext};
 use mint::Vector2;
 use std::sync::Arc;
@@ -14,9 +12,9 @@ use winit::window::{Fullscreen, Window as WinitWindow, WindowBuilder};
 pub struct Window(pub(crate) Arc<WindowContents>);
 
 pub(crate) struct WindowContents {
-    #[cfg(any(target_arch = "wasm32", not(feature = "gl")))]
+    #[cfg(target_arch = "wasm32")]
     window: WinitWindow,
-    #[cfg(all(feature = "gl", not(target_arch = "wasm32")))]
+    #[cfg(not(target_arch = "wasm32"))]
     window: WindowedContext<PossiblyCurrent>,
 }
 
@@ -28,48 +26,7 @@ fn fullscreen_convert(fullscreen: bool, monitor: MonitorHandle) -> Option<Fullsc
     }
 }
 
-#[cfg(all(feature = "stdweb", target_arch = "wasm32"))]
-fn insert_canvas(
-    window: &WinitWindow,
-    _settings: &Settings,
-) -> std_web::web::html_element::CanvasElement {
-    use std_web::traits::*;
-    use std_web::web::document;
-    use winit::platform::web::WindowExtStdweb;
-
-    let canvas = window.canvas();
-    let document = document();
-    document
-        .body()
-        .expect("Document has no body node")
-        .append_child(&canvas);
-
-    canvas.focus();
-
-    #[cfg(feature = "favicon")]
-    {
-        if let Some(path) = _settings.icon_path {
-            let head = document.head().expect("Failed to find head node");
-            let element = document
-                .create_element("link")
-                .expect("Failed to create link element");
-            element
-                .set_attribute("rel", "shortcut icon")
-                .expect("Failed to create favicon element");
-            element
-                .set_attribute("type", "image/png")
-                .expect("Failed to create favicon element");
-            element
-                .set_attribute("href", path)
-                .expect("Failed to create favicon element");
-            head.append_child(&element);
-        }
-    }
-
-    canvas
-}
-
-#[cfg(all(feature = "web-sys", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 fn insert_canvas(window: &WinitWindow, _settings: &Settings) -> web_sys::HtmlCanvasElement {
     use winit::platform::web::WindowExtWebSys;
     let canvas = window.canvas();
@@ -82,7 +39,7 @@ fn insert_canvas(window: &WinitWindow, _settings: &Settings) -> web_sys::HtmlCan
         .append_child(&canvas)
         .expect("Failed to insert canvas");
 
-    canvas.focus();
+    canvas.focus().unwrap();
 
     #[cfg(feature = "favicon")]
     {
@@ -106,9 +63,6 @@ fn insert_canvas(window: &WinitWindow, _settings: &Settings) -> web_sys::HtmlCan
 
     canvas
 }
-
-#[cfg(all(not(feature = "gl"), not(target_arch = "wasm32")))]
-fn insert_canvas(_window: &WinitWindow, _settings: &Settings) {}
 
 fn settings_to_wb(el: &EventLoop<()>, settings: &Settings) -> WindowBuilder {
     #[cfg(feature = "image")]
@@ -142,13 +96,13 @@ fn settings_to_wb(el: &EventLoop<()>, settings: &Settings) -> WindowBuilder {
 impl WindowContents {
     pub(crate) fn new(el: &EventLoop<()>, settings: Settings) -> WindowContents {
         let wb = settings_to_wb(el, &settings);
-        #[cfg(any(not(feature = "gl"), target_arch = "wasm32"))]
+        #[cfg(target_arch = "wasm32")]
         let window = {
             let window = wb.build(el).expect("Failed to create window");
             insert_canvas(&window, &settings);
             WindowContents { window }
         };
-        #[cfg(all(feature = "gl", not(target_arch = "wasm32")))]
+        #[cfg(not(target_arch = "wasm32"))]
         let window = {
             let mut cb = glutin::ContextBuilder::new().with_vsync(settings.vsync);
             if let Some(msaa) = settings.multisampling {
@@ -163,63 +117,8 @@ impl WindowContents {
 
         window
     }
-
-    #[cfg(feature = "gl")]
-    pub(crate) fn new_gl(el: &EventLoop<()>, settings: Settings) -> (WindowContents, Context) {
-        let window = WindowContents::new(el, settings);
-
-        #[cfg(target_arch = "wasm32")]
-        let ctx = {
-            #[cfg(feature = "stdweb")]
-            let ctx = {
-                use std_web::js;
-                use std_web::unstable::TryInto;
-
-                use winit::platform::web::WindowExtStdweb;
-
-                let canvas = window.window.canvas();
-                js! (
-                    return @{canvas}.getContext("webgl", {
-                        alpha: false,
-                        premultipliedAlpha: false,
-                    });
-                )
-                .into_reference()
-                .unwrap()
-                .try_into()
-                .unwrap()
-            };
-            #[cfg(feature = "web-sys")]
-            let ctx = {
-                use js_sys::{Map, Object};
-                use wasm_bindgen::{JsCast, JsValue};
-                use winit::platform::web::WindowExtWebSys;
-                let map = Map::new();
-                map.set(&JsValue::from_str("premultipliedAlpha"), &JsValue::FALSE);
-                map.set(&JsValue::from_str("alpha"), &JsValue::FALSE);
-                let props = Object::from_entries(&map).expect("TODO");
-
-                window
-                    .window
-                    .canvas()
-                    .get_context_with_context_options("webgl", &props)
-                    .expect("Failed to acquire a WebGL rendering context")
-                    .expect("Failed to acquire a WebGL rendering context")
-                    .dyn_into::<web_sys::WebGlRenderingContext>()
-                    .expect("WebGL context of unexpected type")
-            };
-
-            glow::Context::from_webgl1_context(ctx)
-        };
-        #[cfg(not(target_arch = "wasm32"))]
-        let ctx = {
-            glow::Context::from_loader_function(|s| window.window.get_proc_address(s) as *const _)
-        };
-
-        (window, ctx)
-    }
-
-    pub fn set_cursor_icon(&self, icon: Option<CursorIcon>) {
+  
+    fn set_cursor_icon(&self, icon: Option<CursorIcon>) {
         match icon {
             Some(icon) => {
                 self.window().set_cursor_visible(true);
@@ -231,34 +130,11 @@ impl WindowContents {
         }
     }
 
-    pub fn size(&self) -> Vector2<f32> {
-        let size = self.window().inner_size();
-        let size: LogicalSize<f64> = size.to_logical(self.window().scale_factor());
-        Vector2 {
-            x: size.width as f32,
-            y: size.height as f32,
-        }
-    }
-
-    pub fn set_size(&self, size: Vector2<f32>) {
-        let scale = self.window().scale_factor();
-        self.window().set_inner_size(
-            LogicalSize {
-                width: size.x as f64,
-                height: size.y as f64,
-            }
-            .to_physical::<f64>(scale),
-        );
-    }
-
-    pub fn set_title(&self, title: &str) {
+    fn set_title(&self, title: &str) {
         #[cfg(not(target_arch = "wasm32"))]
         self.window().set_title(title);
 
-        #[cfg(all(target_arch = "wasm32", feature = "stdweb"))]
-        std_web::web::document().set_title(title);
-
-        #[cfg(all(target_arch = "wasm32", feature = "web-sys"))]
+        #[cfg(target_arch = "wasm32")]
         web_sys::window()
             .expect("Failed to obtain window")
             .document()
@@ -266,33 +142,20 @@ impl WindowContents {
             .set_title(title);
     }
 
-    pub fn set_fullscreen(&self, fullscreen: bool) {
-        self.window().set_fullscreen(fullscreen_convert(
-            fullscreen,
-            self.window().current_monitor(),
-        ));
-    }
-
     pub(crate) fn resize(&self, _size: PhysicalSize<u32>) {
-        #[cfg(all(feature = "gl", not(target_arch = "wasm32")))]
+        #[cfg(not(target_arch = "wasm32"))]
         self.window.resize(_size);
     }
-
-    #[cfg(feature = "gl")]
-    pub fn present(&self) {
-        #[cfg(all(feature = "gl", not(target_arch = "wasm32")))]
-        self.window.swap_buffers().expect("Failed to swap buffers")
-    }
-
-    pub fn scale(&self) -> f32 {
+    
+    pub(crate) fn scale(&self) -> f32 {
         self.window().scale_factor() as f32
     }
 
     #[inline]
     fn window(&self) -> &WinitWindow {
-        #[cfg(any(not(feature = "gl"), target_arch = "wasm32"))]
+        #[cfg(target_arch = "wasm32")]
         return &self.window;
-        #[cfg(all(feature = "gl", not(target_arch = "wasm32")))]
+        #[cfg(not(target_arch = "wasm32"))]
         return self.window.window();
     }
 }
@@ -310,7 +173,12 @@ impl Window {
     ///
     /// [`scale`]: Window::scale_factor
     pub fn size(&self) -> Vector2<f32> {
-        self.0.size()
+        let size = self.0.window().inner_size();
+        let size: LogicalSize<f64> = size.to_logical(self.0.window().scale_factor());
+        Vector2 {
+            x: size.width as f32,
+            y: size.height as f32,
+        }
     }
 
     /// The DPI scale factor of the window
@@ -324,7 +192,14 @@ impl Window {
 
     /// Set the size of the inside of the window in logical units
     pub fn set_size(&self, size: Vector2<f32>) {
-        self.0.set_size(size);
+        let scale = self.0.window().scale_factor();
+        self.0.window().set_inner_size(
+            LogicalSize {
+                width: size.x as f64,
+                height: size.y as f64,
+            }
+            .to_physical::<f64>(scale),
+        );
     }
 
     /// Set the title of the window or browser tab
@@ -338,17 +213,46 @@ impl Window {
     /// and fullscreen on macOS). On web, it will become fullscreen after the next user
     /// interaction, due to browser API restrictions.
     pub fn set_fullscreen(&self, fullscreen: bool) {
-        self.0.set_fullscreen(fullscreen);
+        self.0.window().set_fullscreen(fullscreen_convert(
+            fullscreen,
+            self.0.window().current_monitor(),
+        ));
+    }
+    
+    #[cfg(not(target_arch = "wasm32"))]
+    /// Return the address of a given OpenGL function
+    pub fn get_proc_address(&self, func: &str) -> *const core::ffi::c_void {
+        self.0.window.get_proc_address(func)
+    }
+        
+    #[cfg(target_arch = "wasm32")]
+    /// Create a WebGL context from the backing canvas
+    pub fn webgl_context(&self) -> web_sys::WebGlRenderingContext {
+        use js_sys::{Map, Object};
+        use wasm_bindgen::{JsCast, JsValue};
+        use winit::platform::web::WindowExtWebSys;
+        let map = Map::new();
+        map.set(&JsValue::from_str("premultipliedAlpha"), &JsValue::FALSE);
+        map.set(&JsValue::from_str("alpha"), &JsValue::FALSE);
+        let props = Object::from_entries(&map).expect("Failed to create object");
+
+        self.0.window
+            .canvas()
+            .get_context_with_context_options("webgl", &props)
+            .expect("Failed to acquire a WebGL rendering context")
+            .expect("Failed to acquire a WebGL rendering context")
+            .dyn_into::<web_sys::WebGlRenderingContext>()
+            .expect("WebGL context of unexpected type")
     }
 
-    #[cfg(feature = "gl")]
     /// Draw the OpenGL frame to the screen
     ///
     /// If vsync is enabled, this will block until the frame is completed on desktop. On web, there
     /// is no way to control vsync, or to manually control presentation, so this function is a
     /// no-op.
     pub fn present(&self) {
-        self.0.present();
+        #[cfg(not(target_arch = "wasm32"))]
+        self.0.window.swap_buffers().expect("Failed to swap buffers")
     }
 }
 


### PR DESCRIPTION
Without stdweb support and with GL always being initalized, glow doesn't become necessary in the public interface. This is important, because breaking changes of glow shouldn't affect blinds (see ryanisaacg/golem#33).